### PR TITLE
fix(-sponsors-list.html): Center sponsors logos for mobile devices.

### DIFF
--- a/src/views/polymerday-sponsors/polymerday-sponsors-list.html
+++ b/src/views/polymerday-sponsors/polymerday-sponsors-list.html
@@ -50,10 +50,11 @@
         }
       };
 
-      @media (max-width:767px) {
+      @media (max-width:720px) {
 
         .sponsors--container--xl,
-        .sponsors--container--s {
+        .sponsors--container--s,
+        .sponsors--container {
           justify-content: center;
         }
 


### PR DESCRIPTION
I've just centered sponsors logos for mobile due to they're already left aligned for desktop #22 
