### PR TITLE
refactor(theme): use responsive font size for page title

### DIFF
--- a/src/styles/polymerday-theme.html
+++ b/src/styles/polymerday-theme.html
@@ -46,6 +46,7 @@
     --page-title: {
       @apply(--font-primary-thin);
       font-size: 40px;
+      font-size: calc( 30px + (40 - 30) * ( (100vw - 320px) / ( 720 - 320) ));
       letter-spacing: 2px;
       line-height: 1.2; /* 48 */
       color: var(--color-blue-dark);


### PR DESCRIPTION
prevent cropping large words like "patrocinadores" on small devices

Before
![captura de pantalla 2016-10-09 a las 21 03 03](https://cloud.githubusercontent.com/assets/92611/19222916/e2bf04f2-8e63-11e6-870e-cd0f591e1902.png)

After
![captura de pantalla 2016-10-09 a las 21 02 32](https://cloud.githubusercontent.com/assets/92611/19222917/e599ec3c-8e63-11e6-8635-3bbe19868fca.png)
